### PR TITLE
avoid qml module version mismatch on fresh install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -45,6 +45,8 @@ apt upgrade -y
 ## Install unity8 desktop sessions
 apt install -y unity8-desktop-session-mir unity8-desktop-session
 
+apt update && apt upgrade -y
+
 ## Done, let's tell the user
 echo "------ DONE ------"
 echo "You can now logout and select unity8"


### PR DESCRIPTION
avoid qml module version mismatch on fresh 16.04 installations by updating the system after installing unity8.

not updating after installing unity8-desktop-session-mir makes unity8 fail to load with error "libQt5Feedback.so.5: version 'Qt_5' not found (required by /usr/lib/x86_64-linux-gnu/qt5/qml/Ubuntu/Telephony/libtelephonyservice-qml.so)