### PR TITLE
Make sure gnupg is installed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,6 +26,9 @@ function do_install {
 }
 
 function setup_repo {
+  ## Make sure gnupg is installed
+  sudo apt install gnupg
+
   ## Setup ubports repo
   echo "deb http://repo.ubports.com/ $UBUNTU_CODENAME main" | sudo tee /etc/apt/sources.list.d/ubports.list
 


### PR DESCRIPTION
On a minimal installation of Ubuntu 18.04, the package gnupg is not installed, but needed by this script.