### PR TITLE
Clean up the install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@ set -e
 ## Check if we are on xenial or bionic
 source /etc/os-release
 if [ $UBUNTU_CODENAME != "xenial" ] && [ $UBUNTU_CODENAME != "bionic" ]; then
-    echo "This is only supported on Ubuntu xenial and bionic"
+    echo "This is only supported on Ubuntu 16.04 and 18.04."
     exit 1
 fi
 
@@ -27,7 +27,7 @@ function do_install {
 
 function setup_repo {
   ## Make sure gnupg is installed
-  sudo apt install gnupg
+  sudo apt install -y gnupg
 
   ## Setup ubports repo
   echo "deb http://repo.ubports.com/ $UBUNTU_CODENAME main" | sudo tee /etc/apt/sources.list.d/ubports.list
@@ -41,31 +41,9 @@ function install {
   do_install
 }
 
-
-function xenial_install {
-  setup_repo
-
-  ## Add temp repo until merged into the main repo
-  echo "deb http://repo.ubports.com/ xenial_-_mir26 main" | sudo tee -a /etc/apt/sources.list.d/ubports.list
-
-  ## Add pin
-  sudo tee /etc/apt/preferences.d/ubports.pref << EOL
-  Package: *
-  Pin: origin repo.ubports.com
-  Pin-Priority: 2000
-
-  Package: *
-  Pin: release a=xenial_-_mir26
-  Pin-Priority: 5000
-EOL
-
-  do_install
-}
-
-
 case $UBUNTU_CODENAME in
   "xenial")
-    xenial_install
+    install
   ;;
   "bionic")
     install


### PR DESCRIPTION
This does a few little cleanup bits:
 - It's a little more user-friendly to say 16.04 and 18.04 than Xenial and Bionic.
 - When installing gnupg, there isn't a reason to prompt the user.
 - In [ubuntu-touch-meta](https://github.com/ubports/ubuntu-touch-meta), `xenial_-_mir26` is 50 commits behind `xenial`. Maybe we should just use the regular `xenial` repo instead.